### PR TITLE
fix: use semantic import versioning for v2 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 1. Use `go get` to install the latest version of the TencentCloud VectorDB Go SDK and dependencies: 
 ```sh
-go get -u github.com/tencent/vectordatabase-sdk-go/tcvectordb
+go get -u github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb
 ```
 
 2. Create New VectorDB Client To Start:
 ```go
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 
 cli, err := tcvectordb.NewRpcClient("vdb http url or ip and post", "root", "key get from web console", &tcvectordb.ClientOption{
 		ReadConsistency: tcvectordb.EventualConsistency,

--- a/example/add_and_drop_index/main.go
+++ b/example/add_and_drop_index/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type Demo struct {

--- a/example/ai_demo/main.go
+++ b/example/ai_demo/main.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_document_set"
-	collection_view "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/collection_view"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_document_set"
+	collection_view "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/collection_view"
 )
 
 type AIDemo struct {

--- a/example/binary_demo/main.go
+++ b/example/binary_demo/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/utils"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/utils"
 )
 
 type Demo struct {

--- a/example/collection_upload_file_demo/main.go
+++ b/example/collection_upload_file_demo/main.go
@@ -9,10 +9,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_document_set"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/document"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_document_set"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/document"
 )
 
 type Demo struct {

--- a/example/count_and_delete_limit_demo/main.go
+++ b/example/count_and_delete_limit_demo/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type Demo struct {

--- a/example/demo/main.go
+++ b/example/demo/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/document"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/document"
 )
 
 type Demo struct {

--- a/example/embedding_demo/main.go
+++ b/example/embedding_demo/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type EmbeddingDemo struct {

--- a/example/embedding_service/main.go
+++ b/example/embedding_service/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"log"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_service"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_service"
 )
 
 type Demo struct {

--- a/example/fulltext_search_demo/main.go
+++ b/example/fulltext_search_demo/main.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type Demo struct {

--- a/example/hnsw_quantization/main.go
+++ b/example/hnsw_quantization/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/index"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/index"
 )
 
 type Demo struct {

--- a/example/hybrid_search_demo/main.go
+++ b/example/hybrid_search_demo/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type Demo struct {

--- a/example/hybrid_search_demo_with_text_encoder/main.go
+++ b/example/hybrid_search_demo_with_text_encoder/main.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type Demo struct {

--- a/example/hybrid_search_with_embedding/main.go
+++ b/example/hybrid_search_with_embedding/main.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type Demo struct {

--- a/example/ivf_rabitq_demo/main.go
+++ b/example/ivf_rabitq_demo/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type IVFRabitQDemo struct {

--- a/example/json_field_and_autoid/main.go
+++ b/example/json_field_and_autoid/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type Demo struct {

--- a/example/modify_vector_index/main.go
+++ b/example/modify_vector_index/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/index"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/index"
 )
 
 type Demo struct {

--- a/example/rebuild_index/main.go
+++ b/example/rebuild_index/main.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type Demo struct {

--- a/example/rpc_client_pool_demo/main.go
+++ b/example/rpc_client_pool_demo/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 func main() {

--- a/example/sparse_vector_demo/main.go
+++ b/example/sparse_vector_demo/main.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type Demo struct {

--- a/example/tls_demo/main.go
+++ b/example/tls_demo/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	tcvectordb "github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	tcvectordb "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 func main() {

--- a/example/ttl_demo/main.go
+++ b/example/ttl_demo/main.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 type Demo struct {

--- a/example/user_demo/main.go
+++ b/example/user_demo/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/user"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/user"
 )
 
 type Demo struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tencent/vectordatabase-sdk-go
+module github.com/tencent/vectordatabase-sdk-go/v2
 
 go 1.17
 

--- a/tcvdbtext/README.md
+++ b/tcvdbtext/README.md
@@ -11,7 +11,7 @@ Go SDK for [Tencent VectorDB Sparse Encoder](https://cloud.tencent.com/document/
 
 1. Use `go get` to install the latest version of the TencentCloud VectorDB Sparse Encoder SDK dependencies: 
 ```sh
-go get -u github.com/tencent/vectordatabase-sdk-go/tcvdbtext
+go get -u github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext
 ```
 
 2. Try [sparse_vector_demo](examples/sparse_vector_demo/main.go) in an online environment with internet access.

--- a/tcvdbtext/encoder/bm25_encoder.go
+++ b/tcvdbtext/encoder/bm25_encoder.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"strconv"
 
-	tcvdbtext "github.com/tencent/vectordatabase-sdk-go/tcvdbtext"
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/tokenizer"
+	tcvdbtext "github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/tokenizer"
 )
 
 const (

--- a/tcvdbtext/encoder/bm25_encoder_test.go
+++ b/tcvdbtext/encoder/bm25_encoder_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/tokenizer"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/tokenizer"
 )
 
 func Test_BM25Encoder_DownloadParams(t *testing.T) {

--- a/tcvdbtext/encoder/sparse_encoder.go
+++ b/tcvdbtext/encoder/sparse_encoder.go
@@ -1,6 +1,6 @@
 package encoder
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvdbtext/tokenizer"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/tokenizer"
 
 type SparseEncoder interface {
 	encodeSingleDocument(text string) []SparseVecItem

--- a/tcvdbtext/examples/sparse_vector_demo/main.go
+++ b/tcvdbtext/examples/sparse_vector_demo/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
 )
 
 func main() {

--- a/tcvdbtext/examples/sparse_vector_offline_demo/main.go
+++ b/tcvdbtext/examples/sparse_vector_offline_demo/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
 )
 
 func main() {

--- a/tcvdbtext/hash/hash.go
+++ b/tcvdbtext/hash/hash.go
@@ -2,7 +2,7 @@ package hash
 
 import (
 	"github.com/spaolacci/murmur3"
-	tcvdbtext "github.com/tencent/vectordatabase-sdk-go/tcvdbtext"
+	tcvdbtext "github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext"
 )
 
 type HashInterface interface {

--- a/tcvdbtext/tokenizer/jieba_tokenizer.go
+++ b/tcvdbtext/tokenizer/jieba_tokenizer.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/go-ego/gse"
 
-	tcvdbtext "github.com/tencent/vectordatabase-sdk-go/tcvdbtext"
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/hash"
+	tcvdbtext "github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/hash"
 )
 
 type JiebaTokenizer struct {

--- a/tcvectordb/ai_alias.go
+++ b/tcvectordb/ai_alias.go
@@ -21,7 +21,7 @@ package tcvectordb
 import (
 	"context"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_alias"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_alias"
 )
 
 var _ AIAliasInterface = &implementerAIAlias{}

--- a/tcvectordb/ai_collection_view.go
+++ b/tcvectordb/ai_collection_view.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/collection_view"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/collection_view"
 )
 
 var _ AICollectionViewInterface = &implementerCollectionView{}

--- a/tcvectordb/ai_document_set.go
+++ b/tcvectordb/ai_document_set.go
@@ -3,7 +3,7 @@ package tcvectordb
 import (
 	"context"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_document_set"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_document_set"
 )
 
 type AIDocumentSetInterface interface {

--- a/tcvectordb/ai_document_sets.go
+++ b/tcvectordb/ai_document_sets.go
@@ -34,8 +34,8 @@ import (
 	"log"
 
 	"github.com/pkg/errors"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_document_set"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_document_set"
 	"github.com/tencentyun/cos-go-sdk-v5"
 )
 

--- a/tcvectordb/api/ai_alias/api.go
+++ b/tcvectordb/api/ai_alias/api.go
@@ -18,7 +18,7 @@
 
 package ai_alias
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 
 type SetReq struct {
 	api.Meta       `path:"/ai/alias/set" tags:"Alias" method:"Post" summary:"指定集合别名，新增/修改"`

--- a/tcvectordb/api/ai_database/api.go
+++ b/tcvectordb/api/ai_database/api.go
@@ -1,6 +1,6 @@
 package ai_database
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 
 type CreateReq struct {
 	api.Meta `path:"/ai/database/create" tags:"Database" method:"Post" summary:"创建ai database，如果database已经存在返回成功"`

--- a/tcvectordb/api/ai_document_set/api.go
+++ b/tcvectordb/api/ai_document_set/api.go
@@ -18,7 +18,7 @@
 
 package ai_document_set
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 
 // QueryReq query document request
 type QueryReq struct {

--- a/tcvectordb/api/ai_document_set/document.go
+++ b/tcvectordb/api/ai_document_set/document.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 )
 
 // Document document struct for document api

--- a/tcvectordb/api/ai_service/api.go
+++ b/tcvectordb/api/ai_service/api.go
@@ -1,6 +1,6 @@
 package ai_service
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 
 type ModelParams struct {
 	RetrieveDenseVector  *bool `json:"retrieveDenseVector,omitempty"`

--- a/tcvectordb/api/alias/api.go
+++ b/tcvectordb/api/alias/api.go
@@ -18,7 +18,7 @@
 
 package alias
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 
 type SetReq struct {
 	api.Meta   `path:"/alias/set" tags:"Alias" method:"Post" summary:"指定集合别名，新增/修改"`

--- a/tcvectordb/api/collection/api.go
+++ b/tcvectordb/api/collection/api.go
@@ -18,7 +18,7 @@
 
 package collection
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 
 // CreateReq create collection request
 type CreateReq struct {

--- a/tcvectordb/api/collection_view/api.go
+++ b/tcvectordb/api/collection_view/api.go
@@ -18,7 +18,7 @@
 
 package collection_view
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 
 // CreateReq create CollectionView request
 type CreateReq struct {

--- a/tcvectordb/api/database/api.go
+++ b/tcvectordb/api/database/api.go
@@ -18,7 +18,7 @@
 
 package database
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 
 // CreateReq create database request
 type CreateReq struct {

--- a/tcvectordb/api/document/api.go
+++ b/tcvectordb/api/document/api.go
@@ -24,8 +24,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_document_set"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_document_set"
 )
 
 // UpsertReq upsert document request

--- a/tcvectordb/api/index/api.go
+++ b/tcvectordb/api/index/api.go
@@ -18,7 +18,7 @@
 
 package index
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 
 type RebuildReq struct {
 	api.Meta          `path:"/index/rebuild" tags:"Index" method:"Post" summary:"重建整个collection的所有索引"`

--- a/tcvectordb/api/user/api.go
+++ b/tcvectordb/api/user/api.go
@@ -18,7 +18,7 @@
 
 package user
 
-import "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+import "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 
 type CreateReq struct {
 	api.Meta `path:"/user/create" tags:"User" method:"Post" summary:"创建用户"`

--- a/tcvectordb/base_alias.go
+++ b/tcvectordb/base_alias.go
@@ -21,7 +21,7 @@ package tcvectordb
 import (
 	"context"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/alias"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/alias"
 )
 
 var _ AliasInterface = &implementerAlias{}

--- a/tcvectordb/base_collection.go
+++ b/tcvectordb/base_collection.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/collection"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/collection"
 )
 
 var _ CollectionInterface = &implementerCollection{}

--- a/tcvectordb/base_database.go
+++ b/tcvectordb/base_database.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_database"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/database"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_database"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/database"
 )
 
 var _ DatabaseInterface = &implementerDatabase{}

--- a/tcvectordb/base_document.go
+++ b/tcvectordb/base_document.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/document"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/document"
 )
 
 var _ DocumentInterface = &implementerDocument{}

--- a/tcvectordb/base_flat.go
+++ b/tcvectordb/base_flat.go
@@ -33,12 +33,12 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_document_set"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_service"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/document"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/user"
-	api_user "github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/user"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_document_set"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_service"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/document"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/user"
+	api_user "github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/user"
 	"github.com/tencentyun/cos-go-sdk-v5"
 )
 

--- a/tcvectordb/base_index_flat.go
+++ b/tcvectordb/base_index_flat.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"log"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/index"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/index"
 )
 
 var _ FlatIndexInterface = &implementerFlatIndex{}

--- a/tcvectordb/client.go
+++ b/tcvectordb/client.go
@@ -30,7 +30,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
 )
 
 // SdkClient provides the operations of a client.

--- a/tcvectordb/helper.go
+++ b/tcvectordb/helper.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/olama"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/olama"
 )
 
 func ConvertDbType(dataType olama.DataType) string {

--- a/tcvectordb/rpc_base_alias.go
+++ b/tcvectordb/rpc_base_alias.go
@@ -3,7 +3,7 @@ package tcvectordb
 import (
 	"context"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/olama"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/olama"
 )
 
 var _ AliasInterface = &rpcImplementerAlias{}

--- a/tcvectordb/rpc_base_collection.go
+++ b/tcvectordb/rpc_base_collection.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/olama"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/olama"
 )
 
 var _ CollectionInterface = &rpcImplementerCollection{}

--- a/tcvectordb/rpc_base_database.go
+++ b/tcvectordb/rpc_base_database.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/olama"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/olama"
 )
 
 var _ DatabaseInterface = &rpcImplementerDatabase{}

--- a/tcvectordb/rpc_base_document.go
+++ b/tcvectordb/rpc_base_document.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/document"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/user"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/olama"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/document"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/user"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/olama"
 )
 
 var _ DocumentInterface = &rpcImplementerDocument{}

--- a/tcvectordb/rpc_base_index.go
+++ b/tcvectordb/rpc_base_index.go
@@ -3,7 +3,7 @@ package tcvectordb
 import (
 	"context"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/olama"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/olama"
 )
 
 var _ IndexInterface = &rpcImplementerIndex{}

--- a/tcvectordb/rpc_base_index_flat.go
+++ b/tcvectordb/rpc_base_index_flat.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/olama"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/olama"
 )
 
 var _ FlatIndexInterface = &rpcImplementerFlatIndex{}

--- a/tcvectordb/rpc_client.go
+++ b/tcvectordb/rpc_client.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/olama"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/olama"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"

--- a/test/aidb_parsing_type_test.go
+++ b/test/aidb_parsing_type_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/collection_view"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/collection_view"
 )
 
 func TestAICreateCollectionViewWithDefaultParsingType(t *testing.T) {

--- a/test/aidb_test.go
+++ b/test/aidb_test.go
@@ -27,10 +27,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_document_set"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/collection_view"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_document_set"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/collection_view"
 )
 
 var (

--- a/test/common.go
+++ b/test/common.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 var (

--- a/test/embedding_svc_test.go
+++ b/test/embedding_svc_test.go
@@ -3,8 +3,8 @@ package test
 import (
 	"testing"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/ai_service"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/ai_service"
 )
 
 func Test_embedding(t *testing.T) {

--- a/test/embedding_test.go
+++ b/test/embedding_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 func TestDropEmbeddingDatabase(t *testing.T) {

--- a/test/filter_test.go
+++ b/test/filter_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 func Test_FilterUint64OneCondition(t *testing.T) {

--- a/test/index_test.go
+++ b/test/index_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/index"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/index"
 )
 
 func TestAddIndexWithDefaultParam(t *testing.T) {

--- a/test/json_field_index_test.go
+++ b/test/json_field_index_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 func Test_CreateCollectionWithJsonFieldIndex(t *testing.T) {

--- a/test/normal_flat_test.go
+++ b/test/normal_flat_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 func TestDropFlatCaseDatabase(t *testing.T) {

--- a/test/normal_test.go
+++ b/test/normal_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/document"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/document"
 )
 
 func TestDropDatabase(t *testing.T) {

--- a/test/sparse_vector_test.go
+++ b/test/sparse_vector_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvdbtext/encoder"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
 )
 
 func TestDropSparseCaseDatabase(t *testing.T) {

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
-	"github.com/tencent/vectordatabase-sdk-go/tcvectordb/api/user"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb"
+	"github.com/tencent/vectordatabase-sdk-go/v2/tcvectordb/api/user"
 )
 
 func Test_DropUser(t *testing.T) {


### PR DESCRIPTION
## What changed

- change the module path to `github.com/tencent/vectordatabase-sdk-go/v2`
- migrate internal, test, and example imports to the v2 path
- update README installation and import examples

## Why

Go modules at major version 2 or later must include the major version suffix in the module and import paths. Without `/v2`, the existing v2 tags cannot be resolved through the Go module proxy.

Fixes #7.

## Validation

- `go test ./tcvdbtext/... ./tcvectordb/... ./example/...`
- `git diff --check`
- verified there are no remaining imports of the unsuffixed module path

`go test ./...` also compiles and passes all packages above, but the repository's `test` package intentionally exits without a live VectorDB address and auth key. `go vet` reports existing warnings in unrelated code (struct tags, a discarded context cancel function, unkeyed dependency literals, and unreachable example code).
